### PR TITLE
FIX: destroy_all methods reordered to work correctly

### DIFF
--- a/app/views/recruits/index.html.erb
+++ b/app/views/recruits/index.html.erb
@@ -1,4 +1,7 @@
 <h1>My Recruits</h1>
+  <div class='d-flex input-group-prepend w-100 flex-grow-1'>
+      <%= render 'shared/search' %>
+  </div>
 <ul>
   <% @recruits.each do |recruit| %>
     <li>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,6 +66,15 @@ ActiveRecord::Schema.define(version: 2020_11_30_040839) do
     t.integer "rating"
   end
 
+  create_table "attendees", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.bigint "recruit_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_attendees_on_event_id"
+    t.index ["recruit_id"], name: "index_attendees_on_recruit_id"
+  end
+
   create_table "calendar_events", force: :cascade do |t|
     t.bigint "event_id", null: false
     t.bigint "calendar_id", null: false
@@ -135,6 +144,8 @@ ActiveRecord::Schema.define(version: 2020_11_30_040839) do
   add_foreign_key "appearances", "recruits"
   add_foreign_key "athlete_events", "athletes"
   add_foreign_key "athlete_events", "events"
+  add_foreign_key "attendees", "events"
+  add_foreign_key "attendees", "recruits"
   add_foreign_key "calendar_events", "calendars"
   add_foreign_key "calendar_events", "events"
   add_foreign_key "calendars", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,13 +7,13 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 puts "Clearing the Database...."
+Appearance.destroy_all
+Event.destroy_all
+Recruit.destroy_all
+Athlete.destroy_all
 User.destroy_all
 Organization.destroy_all
 Sport.destroy_all
-Athlete.destroy_all
-Recruit.destroy_all
-Event.destroy_all
-Appearance.destroy_all
 
 
 puts "Generating Coach & Athletes"


### PR DESCRIPTION
Reordered Database cleansing .destroy_all methods to be in correct order by model associations