### PR TITLE
FEAT: Added clauses to where Event Page will not show the same athlete

### DIFF
--- a/app/assets/stylesheets/events/show.scss
+++ b/app/assets/stylesheets/events/show.scss
@@ -82,6 +82,7 @@
   box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
 }
 
+
 .event-show-card {
   width: 100%;
   height: 100%;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,6 +10,8 @@ class EventsController < ApplicationController
     @note = Note.new
     @notes = @event.notes.order(created_at: :desc)
     @athlete = policy_scope(Athlete).sample
+    recruits = policy_scope(Recruit).map { |rec_hash| rec_hash[:athlete_id] }
+    recruits.exclude?(@athlete.id) ? @athlete : @athlete = policy_scope(Athlete).last
     @schedules = current_user.team.schedules
     @schedule = current_user.team.selected_schedule || @schedules.first
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,7 +18,9 @@ class PagesController < ApplicationController
     # @events = @team.selected_schedule.events
     @event = @schedule.events.first
     @athletes = policy_scope(Athlete)
-    @athlete = (policy_scope(Athlete).where(!policy_scope(Recruit))).sample
+    @athlete = policy_scope(Athlete).sample
+    recruits = policy_scope(Recruit).map { |rec_hash| rec_hash[:athlete_id] }
+    recruits.exclude?(@athlete.id) ? @athlete : @athlete = policy_scope(Athlete).last
     @recruits = @team.recruits.all
     @unavailable_day = UnavailableDay.new
     @unavailable_days = policy_scope(Event).order(created_at: :desc)

--- a/app/controllers/schedule_events_controller.rb
+++ b/app/controllers/schedule_events_controller.rb
@@ -6,7 +6,7 @@ class ScheduleEventsController < ApplicationController
     @user = User.find_by_first_name(schedule_event_params[:user])
     @schedule_event.update(user: @user)
     # render json: { status: 'ok' }
-    redirect_to '/dashboard'
+    redirect_to request.referrer
   end
 
   private

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -18,12 +18,13 @@
     </div>
 
     <div class="event-show-middle p-3 d-flex justify-content-around mb-4">
-      <% schedule_event = ScheduleEvent.find_by event: @event, schedule: @schedule %>
+      <% @schedule_event = ScheduleEvent.find_by event: @event, schedule: @schedule %>
       <% team_members = [] %>
       <% current_user.team.users.each do |user| %>
       <% team_members << (@user = user.first_name) if user.unavailable_days.map { |ud_hash| ud_hash[:date] }.exclude?(@event.start_date) %>
       <% end %>
-      <%= render partial: 'shared/assignedform', locals: { event: @event, schedule: @schedule, schedule_event: schedule_event, team_members: team_members} %>
+      <h2 class="text-grey"><%= @schedule_event.user.first_name if @schedule_event.user %></h2>
+      <%= render partial: 'shared/assignedform', locals: { event: @event, schedule: @schedule, schedule_event: @schedule_event, team_members: team_members} %>
     </div>
 
     <div class="event-show-middle p-3 d-flex justify-content-around">

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -16,10 +16,10 @@
 
       <div class="tab-pane fade show active" id="home" role="tabpanel" aria-labelledby="home-tab">
         <div class="row py-3">
-          <div class="col-xl-7">
+          <div class="col-xl-8">
             <%= render partial: 'events/month', locals: { schedule: @schedule, schedule_event: @schedule_event }  %>
           </div>
-          <div class="col-xl-5">
+          <div class="col-xl-4">
             <%= render partial: 'events/upcomingevent', locals: { event: @event, athlete: @athlete }   %>
             <%= render 'shared/form' %>
           </div>


### PR DESCRIPTION
Set clause were event can't have the same athlete as recruit on dashboard or event show page
Made to where assigned form doesn't jump back to dashboard after assigning a coach
Made Coaches name visible on event page when they are assigned